### PR TITLE
hide password retrieval printout

### DIFF
--- a/client/pwmgr.sh
+++ b/client/pwmgr.sh
@@ -317,7 +317,11 @@ function get ()
 				echo
 				echo "title: $title"
 				echo "username: $username"
-				echo "password: $pw"
+				echo -n "password (hidden): "
+				tput setaf 0 ; tput setb 0  # hide password
+				echo -n "$pw"
+				tput sgr0  # reset terminal back to normal colors
+				echo  # new line after terminal color reset
 				echo "extra info: $extra"
 				;;
 			3)


### PR DESCRIPTION
Make password retrieval printout human unreadable to avoid over-the-shoulder password leak, while still being possible to copy.