### PR TITLE
updated readme and enc password repeat at faulty input when updating …

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Init must be run first to create a session before the other commands can be used
 - init / config<br>
   Create a session. This creates a local session config and attempts to create a remote server db session. If the username db already exists, it's reused. Previous session password must match.<br>
   By entering the same sessionuser/sessionpassword  multiple clients can be used with the same server DB.<br><br>
-- init-change / config-change<br>
+- init-change / config-change / configchange<br>
   Change credentials of an existing session. Old credentials must be given for verification.<br><br>
-- status / check<br>
+- status / check / connection / test<br>
   Check session status against the server.<br><br>
 - add / encrypt / enc / put / save<br>
   Add a new record.<br>

--- a/client/pwmgr.sh
+++ b/client/pwmgr.sh
@@ -492,15 +492,25 @@ function update ()
 		echo ; echo "Error: session password can't be empty."; exit 1
 	fi
 	echo ; read -p "Extra field (may be blank): " extra
-	echo ; read -s -p "Enter encryption password: " encryptionpw
-	echo ; read -s -p "Repeat encryption password: " encryptionpw2
-	if [ "$encryptionpw" != "$encryptionpw2" ]; then
-		echo ; echo "Error: Encryption passwords don't match."; exit 1
-	elif [ "$encryptionpw" == "$pw" ]; then
-		echo ; echo "Error: session password and encryption password shouldn't be the same."; exit 1
-	elif [ "$encryptionpw" == '' ]; then
-		echo ; echo "Error: Encryption password can't be empty."; exit 1
-	fi
+	while true; do
+		echo ; read -s -p "Enter encryption password (or quit):" encryptionpw
+		if [ "$encryptionpw" == "q" ] || [ "$encryptionpw" == "Q" ] || [ "$encryptionpw" == "quit" ] || [ "$encryptionpw" == "QUIT" ] || [ "$encryptionpw" == "exit" ] || [ "$encryptionpw" == "EXIT" ]; then
+			echo ; exit 1
+		fi
+		echo ; read -s -p "Repeat encryption password (or quit):" encryptionpw2
+		if [ "$encryptionpw2" == "q" ] || [ "$encryptionpw2" == "Q" ] || [ "$encryptionpw2" == "quit" ] || [ "$encryptionpw2" == "QUIT" ] || [ "$encryptionpw2" == "exit" ] || [ "$encryptionpw2" == "EXIT" ]; then
+			echo ; exit 1
+		fi
+		if [ "$encryptionpw" != "$encryptionpw2" ]; then
+			echo ; echo ; echo "Error: Encryption passwords don't match."
+		elif [ "$encryptionpw" == "$pw" ]; then
+			echo ; echo ; echo "Error: Record password and encryption password shouldn't be the same."
+		elif [ "$encryptionpw" == '' ]; then
+			echo ; echo ; echo "Error: Encryption password can't be empty."
+		else
+			break
+		fi
+	done
 
 	# encrypt user and pw
 	title=$(echo "$title" | base64 | base64)


### PR DESCRIPTION
- updated readme with more alternative commands
- encryption password prompt at faulty input in the same way as in the "add" routine